### PR TITLE
ParseCh introduced

### DIFF
--- a/ns.go
+++ b/ns.go
@@ -53,6 +53,10 @@ func Parse(r io.Reader) (Namespace, error) {
 	// key=value
 	lines := fread.Fread(r)
 
+	return ParseCh(lines)
+}
+
+func ParseCh(lines <-chan string) (Namespace, error) {
 	type nsSetter func(values ...string)
 	ns := make(Namespace)
 	makeNSSetter := func(nsKeys ...string) nsSetter {


### PR DESCRIPTION
Introduced an API to parse from a channel
of strings. A utility of this API is for example
drive which needs to do pre-filtering over lines
in its .driverc file at that point for which we'll
no longer have an io.Reader. It is more convenient
to just send input via a channel.